### PR TITLE
Increase the accessibility of the logo

### DIFF
--- a/naturescot/components/header/template.njk
+++ b/naturescot/components/header/template.njk
@@ -4,7 +4,7 @@
     <div class="naturescot-header__logo">
       <a href="{{ params.homepageUrl | default('/') }}" class="naturescot-header__link naturescot-header__link--homepage">
         <span class="naturescot-header__logotype">
-          <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 528.25 69.23" width="168" height="22">
+          <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 528.25 69.23" width="168" height="22" role="img" aria-label="NatureScot Logo">
             <defs>
               <linearGradient id="naturescot-header-gradient" x1="75.29" y1="56.38" x2="96.66" y2="10.55" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="currentColor"/><stop offset="1" stop-color="currentColor" stop-opacity="0"/></linearGradient>
             </defs>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "naturescot-frontend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naturescot-frontend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "NatureScot's extensions to GDS' govuk-frontend",
   "author": "Mike Coats <mike.coats@nature.scot>",
   "repository": "github:Scottish-Natural-Heritage/naturescot-frontend",


### PR DESCRIPTION
In the GDS component, only the crown is in the SVG, and the text is in a span. Our logotype uses a custom font, so the text is embedded as un-accessible paths in the SVG. This adds an aria role and label to the svg element for screen-readers.