### PR TITLE
Patch/revert govuk version

### DIFF
--- a/naturescot/components/cookie-bar/_cookie-bar.scss
+++ b/naturescot/components/cookie-bar/_cookie-bar.scss
@@ -1,6 +1,6 @@
-@import "govuk-frontend/dist/govuk/settings/all";
-@import "govuk-frontend/dist/govuk/tools/all";
-@import "govuk-frontend/dist/govuk/helpers/all";
+@import "govuk-frontend/govuk/settings/all";
+@import "govuk-frontend/govuk/tools/all";
+@import "govuk-frontend/govuk/helpers/all";
 
 @include govuk-exports("naturescot/component/cookie-bar") {
   .naturescot-cookie-bar {

--- a/naturescot/components/footer/_footer.scss
+++ b/naturescot/components/footer/_footer.scss
@@ -1,8 +1,8 @@
-@import "govuk-frontend/dist/govuk/settings/all";
-@import "govuk-frontend/dist/govuk/tools/all";
-@import "govuk-frontend/dist/govuk/helpers/all";
+@import "govuk-frontend/govuk/settings/all";
+@import "govuk-frontend/govuk/tools/all";
+@import "govuk-frontend/govuk/helpers/all";
 
-@import "govuk-frontend/dist/govuk/helpers/typography";
+@import "govuk-frontend/govuk/helpers/typography";
 
 $naturescot-logo: "naturescot-logo.png" !default;
 

--- a/naturescot/components/header/_header.scss
+++ b/naturescot/components/header/_header.scss
@@ -1,8 +1,8 @@
-@import "govuk-frontend/dist/govuk/settings/all";
-@import "govuk-frontend/dist/govuk/tools/all";
-@import "govuk-frontend/dist/govuk/helpers/all";
+@import "govuk-frontend/govuk/settings/all";
+@import "govuk-frontend/govuk/tools/all";
+@import "govuk-frontend/govuk/helpers/all";
 
-@import "govuk-frontend/dist/govuk/helpers/typography";
+@import "govuk-frontend/govuk/helpers/typography";
 
 @include govuk-exports("naturescot/component/header") {
   $naturescot-header-background: #5e8bbf;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "naturescot-frontend",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "naturescot-frontend",
-      "version": "4.5.2",
+      "version": "4.5.3",
       "license": "(MIT OR OGL-UK-3.0 OR Apache-2.0)",
       "devDependencies": {
         "prettier": "^1.19.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "prettier": "^1.19.1"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.4.1",
+        "govuk-frontend": "^4.5.0",
         "sass": "^1.35.2"
       }
     },
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.1.tgz",
-      "integrity": "sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "github:Scottish-Natural-Heritage/naturescot-frontend",
   "license": "(MIT OR OGL-UK-3.0 OR Apache-2.0)",
   "peerDependencies": {
-    "govuk-frontend": "^5.4.1",
+    "govuk-frontend": "^4.5.0",
     "sass": "^1.35.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naturescot-frontend",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "NatureScot's extensions to GDS' govuk-frontend",
   "author": "Mike Coats <mike.coats@nature.scot>",
   "repository": "github:Scottish-Natural-Heritage/naturescot-frontend",


### PR DESCRIPTION
Revert govuk-frontend back to due to 4.5.0 lack of support for legacy browsers like Internet Explorer 8, 9 or 10, or need JavaScript support for Internet Explorer 11