### PR TITLE
Replace all references to mq

### DIFF
--- a/naturescot/components/footer/_footer.scss
+++ b/naturescot/components/footer/_footer.scss
@@ -93,7 +93,7 @@ $naturescot-logo: "naturescot-logo.png" !default;
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1; // Support: Flexbox
-    @include mq($until: tablet) {
+    @include govuk-media-query($until: tablet) {
       -webkit-flex-basis: 320px;
       -ms-flex-preferred-size: 320px;
       flex-basis: 320px; // Support: Flexbox
@@ -103,7 +103,7 @@ $naturescot-logo: "naturescot-logo.png" !default;
   .naturescot-footer__licence-logo {
     display: inline-block;
     margin-right: govuk-spacing(2);
-    @include mq($until: desktop) {
+    @include govuk-media-query($until: desktop) {
       margin-bottom: govuk-spacing(3);
     }
     vertical-align: top;
@@ -145,7 +145,7 @@ $naturescot-logo: "naturescot-logo.png" !default;
   .naturescot-footer__heading {
     @include govuk-responsive-margin(7, "bottom");
     padding-bottom: govuk-spacing(4);
-    @include mq($until: tablet) {
+    @include govuk-media-query($until: tablet) {
       padding-bottom: govuk-spacing(2);
     }
     border-bottom: 1px solid $naturescot-footer-border;
@@ -177,7 +177,7 @@ $naturescot-logo: "naturescot-logo.png" !default;
     -webkit-flex-shrink: 1;
     -ms-flex-negative: 1;
     flex-shrink: 1; // Support: Flexbox
-    @include mq($until: desktop) {
+    @include govuk-media-query($until: desktop) {
       // Make sure columns do not drop below 200px in width
       // Will typically result in wrapping, and end up in a single column on smaller screens.
       -webkit-flex-basis: 200px;
@@ -187,7 +187,7 @@ $naturescot-logo: "naturescot-logo.png" !default;
   }
 
   // If there are only two sections, set the layout to be two-third:one-third on desktop
-  @include mq($from: desktop) {
+  @include govuk-media-query($from: desktop) {
     // We match the first section with `:first-child`.
     // To ensure the section is one of two, we can count backwards using `:nth-last-child(2)`.
     .naturescot-footer__section:first-child:nth-last-child(2) {
@@ -207,7 +207,7 @@ $naturescot-logo: "naturescot-logo.png" !default;
     column-gap: $govuk-gutter; // Support: Columns
   }
 
-  @include mq($from: desktop) {
+  @include govuk-media-query($from: desktop) {
     .naturescot-footer__list--columns-2 {
       -webkit-column-count: 2;
       -moz-column-count: 2;

--- a/naturescot/components/header/_header.scss
+++ b/naturescot/components/header/_header.scss
@@ -84,7 +84,7 @@
     &:link:focus {
       @include govuk-text-colour;
     }
-    
+
   }
 
   .naturescot-header__link--homepage {
@@ -132,7 +132,7 @@
     @include govuk-responsive-margin(2, "bottom");
     padding-right: govuk-spacing(8);
 
-    @include mq($from: desktop) {
+    @include govuk-media-query($from: desktop) {
       width: 33.33%;
       padding-right: $govuk-gutter-half;
       float: left;
@@ -141,7 +141,7 @@
   }
 
   .naturescot-header__content {
-    @include mq($from: desktop) {
+    @include govuk-media-query($from: desktop) {
       width: 66.66%;
       padding-left: $govuk-gutter-half;
       float: left;
@@ -174,7 +174,7 @@
       margin-left: govuk-spacing(1);
     }
 
-    @include mq($from: tablet) {
+    @include govuk-media-query($from: tablet) {
       top: govuk-spacing(3);
     }
   }
@@ -196,14 +196,14 @@
   .js-enabled {
     .naturescot-header__menu-button {
       display: block;
-      @include mq($from: desktop) {
+      @include govuk-media-query($from: desktop) {
         display: none;
       }
     }
 
     .naturescot-header__navigation {
       display: none;
-      @include mq($from: desktop) {
+      @include govuk-media-query($from: desktop) {
         display: block;
       }
     }
@@ -214,7 +214,7 @@
   }
 
   .naturescot-header__navigation--end {
-    @include mq($from: desktop) {
+    @include govuk-media-query($from: desktop) {
       margin: 0;
       padding: govuk-spacing(1) 0;
       text-align: right;
@@ -229,7 +229,7 @@
     padding: govuk-spacing(2) 0;
     border-bottom: 1px solid $naturescot-header-nav-item-border-color;
 
-    @include mq($from: desktop) {
+    @include govuk-media-query($from: desktop) {
       display: inline-block;
       margin-right: govuk-spacing(3);
       padding: govuk-spacing(1) 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naturescot-frontend",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "NatureScot's extensions to GDS' govuk-frontend",
   "author": "Mike Coats <mike.coats@nature.scot>",
   "repository": "github:Scottish-Natural-Heritage/naturescot-frontend",


### PR DESCRIPTION
- With the govuk-media-query mixin
- As they have removed the bundled dependency (sass-mq)

Can be "tested" by a find and replace on the `node_modules\naturescot-frontend\naturescot\components\header\_header.scss` and `node_modules\naturescot-frontend\naturescot\components\footer\_footer.scss` followed by `npm run build:ui` in muriburn