### PR TITLE
Fix audit and deprecation warnings

### DIFF
--- a/naturescot/all.scss
+++ b/naturescot/all.scss
@@ -5,7 +5,7 @@ $naturescot-assets: $path-prefix + '/naturescot-frontend/assets/' !default;
 
 @forward 'govuk-frontend/dist/govuk' with (
   $govuk-font-family: $font-family,
-  $govuk-assets-path: $naturescot-assets,
+  $govuk-assets-path: $govuk-assets,
   $govuk-new-organisation-colours: true
 );
 

--- a/naturescot/all.scss
+++ b/naturescot/all.scss
@@ -1,1 +1,12 @@
-@import "components/all";
+$font-family: 'Roboto' !default;
+$path-prefix: '' !default;
+$govuk-assets: $path-prefix + '/govuk-frontend/dist/govuk/' !default;
+$naturescot-assets: $path-prefix + '/naturescot-frontend/assets/' !default;
+
+@forward 'govuk-frontend/dist/govuk' with (
+  $govuk-font-family: $font-family,
+  $govuk-assets-path: $naturescot-assets,
+  $govuk-new-organisation-colours: true
+);
+
+@forward 'components/all';

--- a/naturescot/components/_all.scss
+++ b/naturescot/components/_all.scss
@@ -1,3 +1,3 @@
-@import "header/header";
-@import "footer/footer";
-@import "cookie-bar/cookie-bar";
+@forward "header/header" ;
+@forward "footer/footer" ;
+@forward "cookie-bar/cookie-bar" ;

--- a/naturescot/components/cookie-bar/_cookie-bar.scss
+++ b/naturescot/components/cookie-bar/_cookie-bar.scss
@@ -1,6 +1,4 @@
-@import "govuk-frontend/dist/govuk/settings/index";
-@import "govuk-frontend/dist/govuk/tools/index";
-@import "govuk-frontend/dist/govuk/helpers/index";
+@use "govuk-frontend/dist/govuk" as *;
 
 @include govuk-exports("naturescot/component/cookie-bar") {
   .naturescot-cookie-bar {

--- a/naturescot/components/footer/_footer.scss
+++ b/naturescot/components/footer/_footer.scss
@@ -1,8 +1,4 @@
-@import "govuk-frontend/dist/govuk/settings/index";
-@import "govuk-frontend/dist/govuk/tools/index";
-@import "govuk-frontend/dist/govuk/helpers/index";
-
-@import "govuk-frontend/dist/govuk/helpers/typography";
+@use "govuk-frontend/dist/govuk" as *;
 
 $naturescot-logo: "naturescot-logo.png" !default;
 
@@ -20,17 +16,17 @@ $naturescot-logo: "naturescot-logo.png" !default;
   $naturescot-footer-crest-image-width-original: 512px;
   $naturescot-footer-crest-image-height-original: 430px;
   // Divide by 3 (rather than halve) the new image so that it fits the regular 1x size but maintains aspect ratio.
-  $naturescot-footer-crest-image-width: ($naturescot-footer-crest-image-width-original / 3);
-  $naturescot-footer-crest-image-height: ($naturescot-footer-crest-image-height-original / 3);
+  $naturescot-footer-crest-image-width: calc($naturescot-footer-crest-image-width-original / 3);
+  $naturescot-footer-crest-image-height: calc($naturescot-footer-crest-image-height-original / 3);
 
   .naturescot-footer {
-    @include govuk-font($size: 16);
-    @include govuk-responsive-padding(7, "top");
-    @include govuk-responsive-padding(5, "bottom");
-
     border-top: 1px solid $naturescot-footer-border-top;
     color: $naturescot-footer-text;
     background: $naturescot-footer-background;
+
+    @include govuk-font($size: 16);
+    @include govuk-responsive-padding(7, "top");
+    @include govuk-responsive-padding(5, "bottom");
   }
 
   .naturescot-footer__link {
@@ -57,9 +53,9 @@ $naturescot-logo: "naturescot-logo.png" !default;
 
   .naturescot-footer__section-break {
     margin: 0; // Reset `<hr>` default margins
-    @include govuk-responsive-margin(8, "bottom");
     border: 0; // Reset `<hr>` default borders
     border-bottom: 1px solid $naturescot-footer-border;
+    @include govuk-responsive-margin(8, "bottom");
   }
 
   .naturescot-footer__meta {
@@ -103,10 +99,10 @@ $naturescot-logo: "naturescot-logo.png" !default;
   .naturescot-footer__licence-logo {
     display: inline-block;
     margin-right: govuk-spacing(2);
+    vertical-align: top;
     @include govuk-media-query($until: desktop) {
       margin-bottom: govuk-spacing(3);
     }
-    vertical-align: top;
   }
 
   .naturescot-footer__licence-description {
@@ -143,12 +139,12 @@ $naturescot-logo: "naturescot-logo.png" !default;
   }
 
   .naturescot-footer__heading {
-    @include govuk-responsive-margin(7, "bottom");
     padding-bottom: govuk-spacing(4);
+    border-bottom: 1px solid $naturescot-footer-border;
+    @include govuk-responsive-margin(7, "bottom");
     @include govuk-media-query($until: tablet) {
       padding-bottom: govuk-spacing(2);
     }
-    border-bottom: 1px solid $naturescot-footer-border;
   }
 
   .naturescot-footer__navigation {

--- a/naturescot/components/header/_header.scss
+++ b/naturescot/components/header/_header.scss
@@ -1,8 +1,4 @@
-@import "govuk-frontend/dist/govuk/settings/index";
-@import "govuk-frontend/dist/govuk/tools/index";
-@import "govuk-frontend/dist/govuk/helpers/index";
-
-@import "govuk-frontend/dist/govuk/helpers/typography";
+@use "govuk-frontend/dist/govuk" as *;
 
 @include govuk-exports("naturescot/component/header") {
   $naturescot-header-background: #5e8bbf;
@@ -15,11 +11,11 @@
   $naturescot-header-nav-item-border-color: #2e3133;
 
   .naturescot-header {
-    @include govuk-font($size: 16);
-
     border-bottom: govuk-spacing(2) solid govuk-colour("white");
     color: $naturescot-header-text;
     background: $naturescot-header-background;
+
+    @include govuk-font($size: 16);
   }
 
   .naturescot-header__container--full-width {
@@ -60,9 +56,9 @@
   }
 
   .naturescot-header__product-name {
-    @include govuk-font($size: 24, $line-height: 1);
     display: inline-table;
     padding-right: govuk-spacing(2);
+    @include govuk-font($size: 24, $line-height: 1);
   }
 
   .naturescot-header__link {
@@ -84,14 +80,11 @@
     &:link:focus {
       @include govuk-text-colour;
     }
-
   }
 
   .naturescot-header__link--homepage {
     // Font size needs to be set on the link so that the box sizing is correct
     // in Firefox
-    @include govuk-font($size: false, $weight: bold);
-
     display: inline-block;
     font-size: 30px; // We don't have a mixin that produces 30px font size
     line-height: 1;
@@ -115,6 +108,8 @@
       margin-bottom: 0;
       border-bottom: 0;
     }
+
+    @include govuk-font($size: false, $weight: bold);
   }
 
   .naturescot-header__link--service-name {
@@ -149,7 +144,6 @@
   }
 
   .naturescot-header__menu-button {
-    @include govuk-font($size: 16);
     display: none;
     position: absolute;
     top: govuk-spacing(4);
@@ -177,6 +171,8 @@
     @include govuk-media-query($from: tablet) {
       top: govuk-spacing(3);
     }
+
+    @include govuk-font($size: 16);
   }
 
   .naturescot-header__menu-button--open {
@@ -237,8 +233,8 @@
     }
 
     a {
-      @include govuk-font($size: 16, $weight: bold);
       white-space: nowrap;
+      @include govuk-font($size: 16, $weight: bold);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "naturescot-frontend",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "naturescot-frontend",
-      "version": "5.9.1",
+      "version": "5.9.2",
       "license": "(MIT OR OGL-UK-3.0 OR Apache-2.0)",
       "devDependencies": {
         "prettier": "^1.19.1"
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "license": "MIT",
       "peer": true
     },
@@ -461,9 +461,9 @@
       "peer": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "optional": true,
       "peer": true,


### PR DESCRIPTION
- ran npm audit fix to fix 2 high severity vulnerabilities
- migrate @import to @use and @forward
- add $govuk-new-organisation-colours: true to use of govuk-frontend
- move nested rules to avoid sass [mixed-decls] deprecation warning
- wrap some expressions in calc as required

It seems you can't use parts of libraries, so naturescot-frontend now forwards the govuk-frontend globally rather than importing parts of it into components, so you should only use the naturescot-frontend in applications rather than using both.