### PR TITLE
Update to govuk-frontend 6.1

### DIFF
--- a/naturescot/all.scss
+++ b/naturescot/all.scss
@@ -1,12 +1,10 @@
-$font-family: 'Roboto' !default;
-$path-prefix: '' !default;
-$govuk-assets: $path-prefix + '/govuk-frontend/dist/govuk/' !default;
-$naturescot-assets: $path-prefix + '/naturescot-frontend/assets/' !default;
+@forward 'settings/all' ;
+
+@use 'settings/all' as *;
 
 @forward 'govuk-frontend/dist/govuk' with (
   $govuk-font-family: $font-family,
   $govuk-assets-path: $govuk-assets,
-  $govuk-new-organisation-colours: true
 );
 
 @forward 'components/all';

--- a/naturescot/components/footer/_footer.scss
+++ b/naturescot/components/footer/_footer.scss
@@ -1,14 +1,15 @@
 @use "govuk-frontend/dist/govuk" as *;
+@use "../../tools/image_url" as *;
 
 $naturescot-logo: "naturescot-logo.png" !default;
 
 @include govuk-exports("naturescot/component/footer") {
-  $naturescot-footer-background: $govuk-canvas-background-colour;
+  $naturescot-footer-background: govuk-functional-colour(template-background);
   $naturescot-footer-border: $govuk-border-colour;
   // This variable can be removed entirely once the legacy palette goes away,
   // as it'll just be the same as $naturescot-footer-border.
   $naturescot-footer-border-top: $govuk-border-colour;
-  $naturescot-footer-text: $govuk-text-colour;
+  $naturescot-footer-text: govuk-functional-colour(text);
   $naturescot-footer-link: $naturescot-footer-text;
 
   // Was originally based on the govuk-crest-2x.png image dimensions, but the new
@@ -47,7 +48,7 @@ $naturescot-logo: "naturescot-logo.png" !default;
     }
 
     &:link:focus {
-      @include govuk-text-colour;
+      color: govuk-functional-colour(text)
     }
   }
 
@@ -113,7 +114,7 @@ $naturescot-logo: "naturescot-logo.png" !default;
     display: inline-block;
     min-width: $naturescot-footer-crest-image-width;
     padding-top: ($naturescot-footer-crest-image-height + govuk-spacing(2));
-    background-image: govuk-image-url($naturescot-logo);
+    background-image: naturescot-image-url($naturescot-logo);
     background-repeat: no-repeat;
     background-position: 50% 0%;
     background-size: $naturescot-footer-crest-image-width $naturescot-footer-crest-image-height;

--- a/naturescot/components/header/_header.scss
+++ b/naturescot/components/header/_header.scss
@@ -78,7 +78,7 @@
     }
 
     &:link:focus {
-      @include govuk-text-colour;
+      color: govuk-functional-colour(text);
     }
   }
 

--- a/naturescot/settings/_all.scss
+++ b/naturescot/settings/_all.scss
@@ -1,0 +1,6 @@
+$font-family: 'Roboto' !default;
+$path-prefix: '' !default;
+$govuk-assets: $path-prefix + '/govuk-frontend/dist/govuk/' !default;
+$naturescot-assets: $path-prefix + '/naturescot-frontend/assets/' !default;
+$naturescot-images-path: $naturescot-assets + 'images/' !default;
+$naturescot-fonts-path: $naturescot-assets + 'fonts/' !default;

--- a/naturescot/tools/_image_url.scss
+++ b/naturescot/tools/_image_url.scss
@@ -1,0 +1,25 @@
+@use "sass:meta";
+
+@use "../settings/all" as *;
+
+/// Image URL
+///
+/// If a custom image-url handler is defined ($naturescot-image-url-function) then
+/// it will be called, otherwise a url will be returned with the filename
+/// appended to the image path.
+///
+/// @param {String} Filename for the image to load
+/// @return {String} URL for the filename, wrapped in `url()`
+/// @access public
+
+@function naturescot-image-url($filename) {
+  // prettier-ignore
+  $custom-function: meta.variable-exists("naturescot-image-url-function")
+    and $naturescot-image-url-function;
+
+  @if $custom-function {
+    @return meta.call($custom-function, $filename);
+  } @else {
+    @return url($naturescot-images-path + $filename);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "naturescot-frontend",
-  "version": "5.9.2",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "naturescot-frontend",
-      "version": "5.9.2",
+      "version": "6.1.0",
       "license": "(MIT OR OGL-UK-3.0 OR Apache-2.0)",
       "devDependencies": {
         "prettier": "^1.19.1"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.9.0",
+        "govuk-frontend": "^6.1.0",
         "sass": "^1.85.1"
       }
     },
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
-      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
+      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "naturescot-frontend",
-  "version": "5.9.3",
+  "version": "6.1.0",
   "description": "NatureScot's extensions to GDS' govuk-frontend",
   "author": "Mike Coats <mike.coats@nature.scot>",
   "repository": "github:Scottish-Natural-Heritage/naturescot-frontend",
   "license": "(MIT OR OGL-UK-3.0 OR Apache-2.0)",
   "peerDependencies": {
-    "govuk-frontend": "^5.9.0",
+    "govuk-frontend": "^6.1.0",
     "sass": "^1.85.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- fixed the path for the naturescot logo in the footer, which was being set to be under the govuk assets, requiring a new function for naturescot image URLs
- replaced use of deprecated features with their replacements